### PR TITLE
Different fuel assemblies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "python.analysis.extraPaths": [
     "./",
     "./fuel_assembly",
+    "./materials"
   ],
   "python.languageServer": "Pylance"
 }

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-split_number = 30
+split_number = 4
 core_height = 3.53 #m
 n_fa = 151
 r_fuel = 7.57/20 #sm
@@ -16,14 +16,14 @@ csv_path = "/home/ubuntu24/Desktop/openmc_ap1000/materials/temperature_distribut
 #Calculation parameters
 batches = 200
 inactive = 10
-particles = 10000
+particles = 100000
 #Number of different fuel assemblies defined as different universes
-dif_fu_cart = ['Z44B2', 'Z44B2',
+dif_fu_cart = ['Z49A2', 'Z49A2',
                'Z40', 'Z24', 'Z33Z2', 'Z24',
-               'Z24', 'Z13', 'Z13',
+               'Z24', 'Z33Z9', 'Z13',
                'Z13', 'Z33Z9', 'Z24',
                'Z24', 'Z13',
-               'Z24', 'Z33Z9',
+               'Z33Z2', 'Z24',
                'Z13',
                'Z33Z2']
 #An array that contains the numbers of the various universes of fuel assemblies on the cartogram.

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-split_number = 3
+split_number = 4
 core_height = 3.53 #m
 n_fa = 151
 r_fuel = 7.57/20 #sm

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-split_number = 3
+split_number = 30
 core_height = 3.53 #m
 n_fa = 151
 r_fuel = 7.57/20 #sm
@@ -8,7 +8,7 @@ rod_pitch = 1.275 #sm
 turnkey_size = 23.4 #sm
 core_barrel_in_r = 339.72/2 #sm
 core_barrel_out_r = 349.88/2 #sm
-b_conc = 16 #g/kg
+b_conc = 4 #g/kg
 #The number of fuel assemblies per row, starting from the bottom of the core map.
 line = [4, 7, 10, 11, 12, 13, 12, 13, 12, 13, 12, 11, 10, 7, 4]
 #Path to the location of files with temperature distributions.
@@ -42,11 +42,11 @@ g3 = [12]
 g4 = [7, 16]
 g5 = [18, 13, 8]
 
-h1 = 3
-h2 = 3
-h3 = 3
-h4 = 3
-h5 = 3
+h1 = 0
+h2 = 0
+h3 = 0
+h4 = 0
+h5 = 0
 
 '''
 half_numbers = [1,  2,  3,  4,

--- a/constants.py
+++ b/constants.py
@@ -19,8 +19,18 @@ inactive = 10
 particles = 10000
 #Number of different fuel assemblies defined as different universes
 n_dif = 18
+dif_fu_cart = ['Z40D2']
+'''
+dif_fu_cart = ['Z44B2', 'Z44B2',
+               'Z40', 'Z24', 'Z33Z2', 'Z24',
+               'Z24', 'Z13', 'Z13',
+               'Z13', 'Z33Z9', 'Z24',
+               'Z24', 'Z13',
+               'Z24', 'Z33Z9',
+               'Z13',
+               'Z3Z2']
+'''
 #An array that contains the numbers of the various universes of fuel assemblies on the cartogram.
-
 half_numbers = [1, 2, 2, 1,
                 3, 4, 5, 6, 5, 4, 3,
                 1, 4, 7, 8, 9, 9, 8, 7, 4, 1,
@@ -55,3 +65,4 @@ half_numbers = [1,  2,  3,  4,
 r_half_numbers = list(reversed(half_numbers))
 half_numbers.append(n_dif)
 numbers = half_numbers + r_half_numbers
+

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-split_number = 4
+split_number = 3
 core_height = 3.53 #m
 n_fa = 151
 r_fuel = 7.57/20 #sm
@@ -18,9 +18,6 @@ batches = 200
 inactive = 10
 particles = 10000
 #Number of different fuel assemblies defined as different universes
-n_dif = 18
-dif_fu_cart = ['Z40D2']
-'''
 dif_fu_cart = ['Z44B2', 'Z44B2',
                'Z40', 'Z24', 'Z33Z2', 'Z24',
                'Z24', 'Z13', 'Z13',
@@ -28,8 +25,7 @@ dif_fu_cart = ['Z44B2', 'Z44B2',
                'Z24', 'Z13',
                'Z24', 'Z33Z9',
                'Z13',
-               'Z3Z2']
-'''
+               'Z33Z2']
 #An array that contains the numbers of the various universes of fuel assemblies on the cartogram.
 half_numbers = [1, 2, 2, 1,
                 3, 4, 5, 6, 5, 4, 3,
@@ -63,6 +59,6 @@ half_numbers = [1,  2,  3,  4,
            5, 11, 16, 20, 23, 25] #Half of the fuel assemblies number on the cartogram without the central cassette
 '''
 r_half_numbers = list(reversed(half_numbers))
-half_numbers.append(n_dif)
+half_numbers.append(len(dif_fu_cart))
 numbers = half_numbers + r_half_numbers
 

--- a/core/core.py
+++ b/core/core.py
@@ -37,11 +37,19 @@ if __name__ == '__main__':
     dif_fa_universe = []
     flag = False
     mat_num = 0
+    fake_grey = []
+    for i in range(0, split_number):
+        fake_grey.append(None)
     for i in range(0, len(dif_fu_cart)):
         dict_fa = find_name(dif_fu_cart[i], fa_types)
+        if dict_fa["grey_enrichment"] == 0:
+            mat_grey = fake_grey
+        else:
+            mat_grey = grey_rods[mat_num]
+            mat_num += 1
         for j in range(0, len(g1)):
             if i == g1[j]-1:
-                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1, grey_rods[i], dict_fa["grey_pos"])
+                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1, mat_grey, dict_fa["grey_pos"])
                 flag = True
                 dif_fa_universe.append(fa_)
                 splits += list(fa_.cells.values())
@@ -52,7 +60,7 @@ if __name__ == '__main__':
         else:
             for j in range(0, len(g2)):
                 if i == g2[j]-1:
-                    fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide2, cr_shell2, h2, grey_rods[i], dict_fa["grey_pos"])
+                    fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide2, cr_shell2, h2, mat_grey, dict_fa["grey_pos"])
                     flag = True
                     dif_fa_universe.append(fa_)
                     splits += list(fa_.cells.values())
@@ -63,7 +71,7 @@ if __name__ == '__main__':
             else:
                 for j in range(0, len(g3)):
                     if i == g3[j]-1:
-                        fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide3, cr_shell3, h3, grey_rods[i], dict_fa["grey_pos"])
+                        fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide3, cr_shell3, h3, mat_grey, dict_fa["grey_pos"])
                         flag = True
                         dif_fa_universe.append(fa_)
                         splits += list(fa_.cells.values())
@@ -74,7 +82,7 @@ if __name__ == '__main__':
                 else:
                     for j in range(0, len(g4)):
                         if i == g4[j]-1:
-                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide4, cr_shell4, h4, grey_rods[i], dict_fa["grey_pos"])
+                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide4, cr_shell4, h4, mat_grey, dict_fa["grey_pos"])
                             flag = True
                             dif_fa_universe.append(fa_)
                             splits += list(fa_.cells.values())
@@ -85,7 +93,7 @@ if __name__ == '__main__':
                     else:
                         for j in range(0, len(g5)):
                             if i == g5[j]-1:
-                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h5, grey_rods[i], dict_fa["grey_pos"])
+                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h5, mat_grey, dict_fa["grey_pos"])
                                 flag = True
                                 dif_fa_universe.append(fa_)
                                 splits += list(fa_.cells.values())
@@ -94,13 +102,12 @@ if __name__ == '__main__':
                             flag = False
                             continue
                         else:
-                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, 0, grey_rods[i], dict_fa["grey_pos"])
+                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, 0, mat_grey, dict_fa["grey_pos"])
                             dif_fa_universe.append(fa_)
                             splits += list(fa_.cells.values())
 
     for i in range(0, n_fa):
         fa_universe.append(dif_fa_universe[numbers[i]-1])
-
 
     print("The core is divided into", len(splits), "elements.")
     fa_universe.append(water_full_fa(coolant[-1]))
@@ -181,7 +188,7 @@ if __name__ == '__main__':
     p.filename = 'cluster_xy'
     p.basis = "xy"
     p.width = (350, 350)
-    p.pixels = (2000, 2000)
+    p.pixels = (6000, 6000)
     p.color_by = 'material'
     plots = openmc.Plots([p])
     plots.export_to_xml()
@@ -193,7 +200,7 @@ if __name__ == '__main__':
     p.filename = 'cluster_yz'
     p.basis = "yz"
     p.width = (500, 500)
-    p.pixels = (1000, 1000)
+    p.pixels = (5000, 5000)
     p.color_by = 'material'
     plots = openmc.Plots([p])
     plots.export_to_xml()

--- a/core/core.py
+++ b/core/core.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
                     else:
                         for j in range(0, len(g5)):
                             if i == g5[j]-1:
-                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h4)
+                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h5)
                                 flag = True
                                 dif_fa_universe.append(fa_)
                                 splits += list(fa_.cells.values())
@@ -93,9 +93,6 @@ if __name__ == '__main__':
                             dif_fa_universe.append(fa_)
                             splits += list(fa_.cells.values())
 
-    print ('####################################')
-    print (len(dif_fa_universe))
-    print ('####################################')
     for i in range(0, n_fa):
         fa_universe.append(dif_fa_universe[numbers[i]-1])
 

--- a/core/core.py
+++ b/core/core.py
@@ -258,9 +258,9 @@ if __name__ == '__main__':
         for j in range(0, split_number):
             kq.append(kq_[(numbers[i] - 1) * split_number + j])
 
-    write_floats_to_file("kq_full.txt", kq, split_number)
+    write_floats_to_file("kv.txt", kq, split_number)
 
-    #Kr calculation
+    #Kq calculation
     kr = []
     for i in range(0, n_fa):
         sum_ = 0
@@ -277,7 +277,7 @@ if __name__ == '__main__':
             xy.append((x,y))
         y += 1.5*turnkey_size/sqrt(3)
     combined_array = [(t[0], t[1], n) for t, n in zip(xy, kr)]
-    np.savetxt(f"kr.txt", combined_array, delimiter="\t", fmt = "%.6f")
+    np.savetxt(f"kq.txt", combined_array, delimiter="\t", fmt = "%.6f")
 
     #Kz calculation
     kz = []

--- a/core/core.py
+++ b/core/core.py
@@ -7,7 +7,8 @@ from collections import Counter
 
 sys.path.append('../')
 from constants import n_fa, turnkey_size, core_barrel_in_r, core_barrel_out_r, core_height, split_number, line
-from constants import batches, particles, inactive, numbers, n_dif, g1, g2, g3, g4, g5, h1, h2, h3, h4, h5
+from constants import batches, particles, inactive, numbers, g1, g2, g3, g4, g5, h1, h2, h3, h4, h5
+from constants import dif_fu_cart
 
 sys.path.append('../'+'fuel_assembly')
 from fuel_assembly import full_fa, water_full_fa
@@ -15,6 +16,8 @@ from fuel_assembly import full_fa, water_full_fa
 sys.path.append('../'+'materials')
 from materials import g_hole, fuel, gaz, shell, coolant, cr_shell1, boron_carbide1
 from materials import cr_shell2, boron_carbide2, cr_shell3, boron_carbide3, cr_shell4, boron_carbide4, cr_shell5, boron_carbide5
+from materials import grey_rods
+from fuel_assemblies import find_name, fa_types
 
 def write_floats_to_file(filename, float_array, elements_per_line):
     with open(filename, 'w') as file:
@@ -23,20 +26,22 @@ def write_floats_to_file(filename, float_array, elements_per_line):
             file.write('\t'.join(f'{num:.7f}' for num in line) + '\n')
 
 if __name__ == '__main__':
-
+    grey_array = [element for sublist in grey_rods for element in sublist]
     mats = openmc.Materials((*g_hole, *fuel, *gaz, *shell, *coolant,
                               *cr_shell1, *cr_shell2, *cr_shell3, *cr_shell4, *cr_shell5,
-                             *boron_carbide1, *boron_carbide2, *boron_carbide3, *boron_carbide4, *boron_carbide5))
+                             *boron_carbide1, *boron_carbide2, *boron_carbide3, *boron_carbide4, *boron_carbide5, *grey_array))
     mats.export_to_xml()
 
     fa_universe = []
     splits = []
     dif_fa_universe = []
     flag = False
-    for i in range(0, n_dif):
+    mat_num = 0
+    for i in range(0, len(dif_fu_cart)):
+        dict_fa = find_name(dif_fu_cart[i], fa_types)
         for j in range(0, len(g1)):
             if i == g1[j]-1:
-                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1)
+                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1, grey_rods[i], dict_fa["grey_pos"])
                 flag = True
                 dif_fa_universe.append(fa_)
                 splits += list(fa_.cells.values())
@@ -47,7 +52,7 @@ if __name__ == '__main__':
         else:
             for j in range(0, len(g2)):
                 if i == g2[j]-1:
-                    fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide2, cr_shell2, h2)
+                    fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide2, cr_shell2, h2, grey_rods[i], dict_fa["grey_pos"])
                     flag = True
                     dif_fa_universe.append(fa_)
                     splits += list(fa_.cells.values())
@@ -58,7 +63,7 @@ if __name__ == '__main__':
             else:
                 for j in range(0, len(g3)):
                     if i == g3[j]-1:
-                        fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide3, cr_shell3, h3)
+                        fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide3, cr_shell3, h3, grey_rods[i], dict_fa["grey_pos"])
                         flag = True
                         dif_fa_universe.append(fa_)
                         splits += list(fa_.cells.values())
@@ -69,7 +74,7 @@ if __name__ == '__main__':
                 else:
                     for j in range(0, len(g4)):
                         if i == g4[j]-1:
-                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide4, cr_shell4, h4)
+                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide4, cr_shell4, h4, grey_rods[i], dict_fa["grey_pos"])
                             flag = True
                             dif_fa_universe.append(fa_)
                             splits += list(fa_.cells.values())
@@ -80,7 +85,7 @@ if __name__ == '__main__':
                     else:
                         for j in range(0, len(g5)):
                             if i == g5[j]-1:
-                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h5)
+                                fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, h5, grey_rods[i], dict_fa["grey_pos"])
                                 flag = True
                                 dif_fa_universe.append(fa_)
                                 splits += list(fa_.cells.values())
@@ -89,7 +94,7 @@ if __name__ == '__main__':
                             flag = False
                             continue
                         else:
-                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, 0)
+                            fa_ = full_fa(i, g_hole, fuel, gaz, shell, coolant, boron_carbide5, cr_shell5, 0, grey_rods[i], dict_fa["grey_pos"])
                             dif_fa_universe.append(fa_)
                             splits += list(fa_.cells.values())
 
@@ -233,7 +238,7 @@ if __name__ == '__main__':
     values=energy_rel.get_values()
     values2=np.array(values.flatten())
     count = Counter(numbers)
-    for i in range(0, n_dif):
+    for i in range(0, len(dif_fu_cart)):
         divider = count[i+1]
         for j in range(i * split_number, (i + 1) * split_number):
             values2[j] /= divider

--- a/fuel_assembly/assembly_element.py
+++ b/fuel_assembly/assembly_element.py
@@ -67,35 +67,39 @@ def fa_split(fa_num, layer_num, c_gaz, fuel, gaz, shell, coolant, b4c, cr_steel,
     fr = openmc.Universe(universe_id = int(4E7 + 1E5 + fa_num*1E2 + layer_num), cells=[central_hole_cell, fuel_cell, gap_cell, clad_cell, water1_cell])
 
     #create grey rod
-    grey_cell = openmc.Cell(cell_id = int(3E7 + 2E5 + fa_num*1E2 + layer_num), fill = g_fuel, region = fuel_region)
-    grey_f = openmc.Universe(universe_id = int(4E7 + 1E5 + fa_num*1E2 + layer_num), cells=[central_hole_cell, grey_cell, gap_cell, clad_cell, water1_cell])
+    central_hole_cell_g = openmc.Cell(cell_id = int(3E7 + 6E5 + fa_num*1E2 + layer_num), fill = c_gaz, region = central_hole_region)
+    gap_cell_g = openmc.Cell(cell_id = int(3E7 + 7E5 + fa_num*1E2 + layer_num), fill = gaz, region = gap_region)
+    clad_cell_g = openmc.Cell(cell_id = int(3E7 + 8E5 + fa_num*1E2 + layer_num), fill = shell, region = clad_region)
+    water1_cell_g = openmc.Cell(cell_id = int(3E7 + 9E5 + fa_num*1E2 + layer_num), fill = coolant, region = +clad_cylinder)
+    grey_cell = openmc.Cell(cell_id = int(3E7 + 10E5 + fa_num*1E2 + layer_num), fill = g_fuel, region = fuel_region)
+    grey_f = openmc.Universe(universe_id = int(4E7 + 2E5 + fa_num*1E2 + layer_num), cells=[central_hole_cell_g, grey_cell, gap_cell_g, clad_cell_g, water1_cell_g])
     #create central tube
-    central_tube_in_cell = openmc.Cell(cell_id = int(3E7 + 6E5 + fa_num*1E2 + layer_num), fill = coolant, region = -central_tube_in_cylinder)
-    central_tube_cell = openmc.Cell(cell_id = int(3E7 + 7E5 + fa_num*1E2 + layer_num), fill = shell, region = central_tube_region)
-    water2_cell = openmc.Cell(cell_id = int(3E7 + 8E5 + fa_num*1E2 + layer_num), fill = coolant, region = +central_tube_out_cylinder)
-    ct = openmc.Universe(universe_id = int(4E7 + 2E5 + fa_num*1E2 + layer_num), cells=[central_tube_in_cell, central_tube_cell, water2_cell])
+    central_tube_in_cell = openmc.Cell(cell_id = int(3E7 + 11E5 + fa_num*1E2 + layer_num), fill = coolant, region = -central_tube_in_cylinder)
+    central_tube_cell = openmc.Cell(cell_id = int(3E7 + 12E5 + fa_num*1E2 + layer_num), fill = shell, region = central_tube_region)
+    water2_cell = openmc.Cell(cell_id = int(3E7 + 13E5 + fa_num*1E2 + layer_num), fill = coolant, region = +central_tube_out_cylinder)
+    ct = openmc.Universe(universe_id = int(4E7 + 3E5 + fa_num*1E2 + layer_num), cells=[central_tube_in_cell, central_tube_cell, water2_cell])
 
     #create control sistem channel
-    csc_cell = openmc.Cell(cell_id = int(3E7 + 9E5 + fa_num*1E2 + layer_num),fill = shell, region = csc_region)
-    water3_cell = openmc.Cell(cell_id = int(3E7 + 10E5 + fa_num*1E2 + layer_num), fill = coolant, region = +csc_out_cylinder)
+    csc_cell = openmc.Cell(cell_id = int(3E7 + 14E5 + fa_num*1E2 + layer_num),fill = shell, region = csc_region)
+    water3_cell = openmc.Cell(cell_id = int(3E7 + 15E5 + fa_num*1E2 + layer_num), fill = coolant, region = +csc_out_cylinder)
     if cr_key == 0:
-        csc_in_cell = openmc.Cell(cell_id = int(3E7 + 11E5 + fa_num*1E2 + layer_num), fill = coolant, region = -csc_in_cylinder)
-        csc = openmc.Universe(universe_id = int(4E7 + 3E5 + fa_num*1E2 + layer_num), cells = [csc_in_cell, csc_cell, water3_cell])
+        csc_in_cell = openmc.Cell(cell_id = int(3E7 + 16E5 + fa_num*1E2 + layer_num), fill = coolant, region = -csc_in_cylinder)
+        csc = openmc.Universe(universe_id = int(4E7 + 4E5 + fa_num*1E2 + layer_num), cells = [csc_in_cell, csc_cell, water3_cell])
     else:
         cr_in_cylinder = openmc.ZCylinder(surface_id=int(2E7 + 11E5 + fa_num*1E2 + layer_num), r=0.35)
         cr_out_cylinder = openmc.ZCylinder(surface_id=int(2E7 + 12E5 + fa_num*1E2 + layer_num), r=0.41)
         cr_shell = +cr_in_cylinder & -cr_out_cylinder
         cr_coolant = +cr_out_cylinder & -csc_in_cylinder
-        cr_b4c_cell = openmc.Cell(cell_id = int(3E7 + 12E5 + fa_num*1E2 + layer_num), fill = b4c, region = -cr_in_cylinder)
-        cr_shell_cell = openmc.Cell(cell_id = int(3E7 + 13E5 + fa_num*1E2 + layer_num), fill = cr_steel, region = cr_shell)
-        cr_coolant_cell = openmc.Cell(cell_id = int(3E7 + 14E5 + fa_num*1E2 + layer_num), fill = coolant, region = cr_coolant)
+        cr_b4c_cell = openmc.Cell(cell_id = int(3E7 + 17E5 + fa_num*1E2 + layer_num), fill = b4c, region = -cr_in_cylinder)
+        cr_shell_cell = openmc.Cell(cell_id = int(3E7 + 18E5 + fa_num*1E2 + layer_num), fill = cr_steel, region = cr_shell)
+        cr_coolant_cell = openmc.Cell(cell_id = int(3E7 + 19E5 + fa_num*1E2 + layer_num), fill = coolant, region = cr_coolant)
         csc = openmc.Universe(universe_id = int(4E7 + 3E5 + fa_num*1E2 + layer_num), cells = [cr_b4c_cell, cr_shell_cell, cr_coolant_cell, csc_cell, water3_cell])
 
 
 
     #coolant universe
-    all_water_out=openmc.Cell(cell_id = int(3E7 + 15E5 + fa_num*1E2 + layer_num), fill=coolant)
-    all_water_out_u=openmc.Universe(universe_id = int(4E7 + 4E5 + fa_num*1E2 + layer_num), cells=[all_water_out])
+    all_water_out=openmc.Cell(cell_id = int(3E7 + 20E5 + fa_num*1E2 + layer_num), fill=coolant)
+    all_water_out_u=openmc.Universe(universe_id = int(4E7 + 5E5 + fa_num*1E2 + layer_num), cells=[all_water_out])
 
     #lattice ID definition
     #5??????? - first 3
@@ -121,15 +125,21 @@ def fa_split(fa_num, layer_num, c_gaz, fuel, gaz, shell, coolant, b4c, cr_steel,
     ring9 = [fr]*9*6
     ring10 = [fr]*10*6
     rings = [ring10, ring9, ring8, ring7, ring6, ring5, ring4, ring3, ring2, ring1, ring0]
-    j = 0
+    count = 0
+    num = 0
     for i in range (0, len(rings)):
-        if i == grey_list[j]:
-            rings[i] = grey_f
-            j += 1
+        for j in range(0, len(rings[i])):
+            if num < len(grey_list):
+                if count == grey_list[num]:
+                    rings[i][j] = grey_f
+                    num += 1
+                count +=1
+            else:
+                break
     lat.universes = rings
 
 
-    assembly_cell = openmc.Cell(cell_id = int(3E7 + 16E5 + fa_num*1E2 + layer_num), name=f'cell_assembly_{fa_num}_layer_{layer_num}' )
+    assembly_cell = openmc.Cell(cell_id = int(3E7 + 21E5 + fa_num*1E2 + layer_num), name=f'cell_assembly_{fa_num}_layer_{layer_num}' )
     hex_prizm = openmc.model.HexagonalPrism(edge_length = turnkey_size/math.sqrt(3), orientation = 'x', boundary_type = "transmission")
     assembly_cell.region = -hex_prizm & -zup & +zdn
     assembly_cell.fill = lat

--- a/fuel_assembly/assembly_element.py
+++ b/fuel_assembly/assembly_element.py
@@ -93,7 +93,7 @@ def fa_split(fa_num, layer_num, c_gaz, fuel, gaz, shell, coolant, b4c, cr_steel,
         cr_b4c_cell = openmc.Cell(cell_id = int(3E7 + 17E5 + fa_num*1E2 + layer_num), fill = b4c, region = -cr_in_cylinder)
         cr_shell_cell = openmc.Cell(cell_id = int(3E7 + 18E5 + fa_num*1E2 + layer_num), fill = cr_steel, region = cr_shell)
         cr_coolant_cell = openmc.Cell(cell_id = int(3E7 + 19E5 + fa_num*1E2 + layer_num), fill = coolant, region = cr_coolant)
-        csc = openmc.Universe(universe_id = int(4E7 + 3E5 + fa_num*1E2 + layer_num), cells = [cr_b4c_cell, cr_shell_cell, cr_coolant_cell, csc_cell, water3_cell])
+        csc = openmc.Universe(universe_id = int(4E7 + 4E5 + fa_num*1E2 + layer_num), cells = [cr_b4c_cell, cr_shell_cell, cr_coolant_cell, csc_cell, water3_cell])
 
 
 

--- a/fuel_assembly/fuel_assembly.py
+++ b/fuel_assembly/fuel_assembly.py
@@ -39,7 +39,7 @@ def water_full_fa(coolant):
 if __name__ == '__main__':
     sys.path.append('../'+'materials')
     from fuel_assemblies import fa_types, find_name
-    fa = find_name("Z40D2", fa_types)
+    fa = find_name("Z49B9", fa_types)
     grey_array = [element for sublist in grey_rods for element in sublist]
     mats = openmc.Materials((*g_hole, *fuel, *gaz, *shell, *coolant, *cr_shell1, *boron_carbide1, *grey_array))
     mats.export_to_xml()

--- a/fuel_assembly/fuel_assembly.py
+++ b/fuel_assembly/fuel_assembly.py
@@ -10,7 +10,7 @@ sys.path.append('../'+'materials')
 from materials import g_hole, fuel, gaz, shell, coolant, cr_shell1, boron_carbide1
 from assembly_element import fa_split
 
-def full_fa(fa_num, c_gaz_list, fuel_list, gaz_list, shell_list, hc_list, b4c_list, cr_steel_list, cr_depth):
+def full_fa(fa_num, c_gaz_list, fuel_list, gaz_list, shell_list, hc_list, b4c_list, cr_steel_list, cr_depth, grey_f_list, fa_dict, name):
     fa_universe_return = openmc.Universe(universe_id = int(4E7 + 5E5 + fa_num*1E2 + split_number), name=f'fa_universe_{fa_num}')
     for i in range (0, split_number - cr_depth):
         num = fa_num*split_number + i

--- a/fuel_assembly/fuel_assembly.py
+++ b/fuel_assembly/fuel_assembly.py
@@ -7,19 +7,19 @@ import sys
 sys.path.append('../')
 from constants import split_number, core_height, n_fa, batches, particles, inactive, turnkey_size, h1
 sys.path.append('../'+'materials')
-from materials import g_hole, fuel, gaz, shell, coolant, cr_shell1, boron_carbide1
+from materials import g_hole, fuel, gaz, shell, coolant, cr_shell1, boron_carbide1, grey_rods
 from assembly_element import fa_split
 
-def full_fa(fa_num, c_gaz_list, fuel_list, gaz_list, shell_list, hc_list, b4c_list, cr_steel_list, cr_depth, grey_f_list, fa_dict, name):
+def full_fa(fa_num, c_gaz_list, fuel_list, gaz_list, shell_list, hc_list, b4c_list, cr_steel_list, cr_depth, grey_mat_list, grey_fa_list):
     fa_universe_return = openmc.Universe(universe_id = int(4E7 + 5E5 + fa_num*1E2 + split_number), name=f'fa_universe_{fa_num}')
     for i in range (0, split_number - cr_depth):
         num = fa_num*split_number + i
-        root_cell = fa_split(fa_num, i, c_gaz_list[num], fuel_list[num], gaz_list[num], shell_list[num], hc_list[num], 0, 0, 0)
+        root_cell = fa_split(fa_num, i, c_gaz_list[num], fuel_list[num], gaz_list[num], shell_list[num], hc_list[num], None, None, 0, grey_mat_list[i], grey_fa_list)
         fa_universe_return.add_cell(root_cell)
     for i in range (split_number - cr_depth, split_number):
         num = fa_num*split_number + i
         cr_num = i - (split_number - cr_depth)
-        root_cell = fa_split(fa_num, i, c_gaz_list[num], fuel_list[num], gaz_list[num], shell_list[num], hc_list[num], b4c_list[cr_num], cr_steel_list[cr_num], 1)
+        root_cell = fa_split(fa_num, i, c_gaz_list[num], fuel_list[num], gaz_list[num], shell_list[num], hc_list[num], b4c_list[cr_num], cr_steel_list[cr_num], 1, grey_mat_list[i], grey_fa_list)
         fa_universe_return.add_cell(root_cell)
     return fa_universe_return
 
@@ -37,14 +37,17 @@ def water_full_fa(coolant):
     return fa_universe_return
 
 if __name__ == '__main__':
-
-    mats = openmc.Materials((*g_hole, *fuel, *gaz, *shell, *coolant, *cr_shell1, *boron_carbide1))
+    sys.path.append('../'+'materials')
+    from fuel_assemblies import fa_types, find_name
+    fa = find_name("Z40D2", fa_types)
+    grey_array = [element for sublist in grey_rods for element in sublist]
+    mats = openmc.Materials((*g_hole, *fuel, *gaz, *shell, *coolant, *cr_shell1, *boron_carbide1, *grey_array))
     mats.export_to_xml()
     zdn_ = openmc.ZPlane(surface_id=int(2E7 + 9E5 + 200*1E2 + 31), z0= 0, boundary_type = 'vacuum')
     zup_ = openmc.ZPlane(surface_id=int(2E7 + 10E5 + 200*1E2 + 32), z0= core_height*1E2, boundary_type = 'vacuum')
     assembly_prism = openmc.model.HexagonalPrism(edge_length = turnkey_size/math.sqrt(3), orientation = 'x', boundary_type = "reflective")
     fa_region = -assembly_prism & -zup_ & +zdn_
-    full_fa_u = full_fa(1, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1 )
+    full_fa_u = full_fa(0, g_hole, fuel, gaz, shell, coolant, boron_carbide1, cr_shell1, h1, grey_rods[0], fa["grey_pos"])
     fa_cell = openmc.Cell(cell_id =  int(3E7 + 13E5 + 200*1E2 + 31), name = "fa1", fill = full_fa_u)
     fa_cell.region = fa_region
     fa_universe = openmc.Universe(universe_id=int(4E7 + 7E5 + 201*1E2 + 33), cells=[fa_cell])

--- a/materials/fuel_assemblies.py
+++ b/materials/fuel_assemblies.py
@@ -1,0 +1,15 @@
+fa_types = [
+    {"name": "Z40",
+     "enrichment": 4.0,
+     "grey_enrichment": 0,
+     "gdo2_wo": 0,
+     "grey_pos": []
+    },
+    {"name": "Z40D2",
+     "enrichment": 4.0,
+     "grey_enrichment": 3.3,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158]
+    }
+
+]

--- a/materials/fuel_assemblies.py
+++ b/materials/fuel_assemblies.py
@@ -5,13 +5,123 @@ fa_types = [
      "gdo2_wo": 0,
      "grey_pos": []
     },
+    {"name": "Z13",
+     "enrichment": 1.3,
+     "grey_enrichment": 0,
+     "gdo2_wo": 0,
+     "grey_pos": []
+    },
+    {"name": "Z24",
+     "enrichment": 2.4,
+     "grey_enrichment": 0,
+     "gdo2_wo": 0,
+     "grey_pos": []
+    },
     {"name": "Z40D2",
      "enrichment": 4.0,
      "grey_enrichment": 3.3,
      "gdo2_wo": 5.0,
      "grey_pos": [114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158]
+    },
+    {"name": "Z40D6",
+     "enrichment": 4.0,
+     "grey_enrichment": 3.3,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154]
+    },
+    {"name": "Z40E9",
+     "enrichment": 4.0,
+     "grey_enrichment": 3.3,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154, 271, 279, 287]
+    },
+    {"name": "Z40U1",
+     "enrichment": 4.0,
+     "grey_enrichment": 3.3,
+     "gdo2_wo": 8.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154,
+                  164, 167, 171, 174, 178, 181, 185, 188, 192, 195, 199, 202,
+                  296, 302, 308]
+    },
+    {"name": "Z40U5",
+     "enrichment": 4.0,
+     "grey_enrichment": 3.3,
+     "gdo2_wo": 8.0,
+     "grey_pos": [114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158,
+                  271, 279, 287]
+    },
+    {"name": "Z44A6",
+     "enrichment": 4.4,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 5.0,
+     "grey_pos": [271, 275, 279, 283, 287, 291]
+    },
+    {"name": "Z44B2",
+     "enrichment": 4.4,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 118, 122, 126, 130, 134, 138, 142, 146, 150, 154, 158]
+    },
+    {"name": "Z44Y7",
+     "enrichment": 4.4,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 8.0,
+     "grey_pos": [63, 66, 72, 75, 81, 84, 90, 93, 99, 102, 108, 111,
+                   114, 122, 130, 138, 146, 154,
+                   205, 211, 217, 223, 229, 235,
+                   312, 316, 320]
+    },
+    {"name": "Z49",
+     "enrichment": 4.95,
+     "grey_enrichment": 0,
+     "gdo2_wo": 0,
+     "grey_pos": []
+    },
+    {"name": "Z49A2",
+     "enrichment": 4.95,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154, 271, 275, 279, 283, 287, 291]
+    },
+    {"name": "Z33Z2",
+     "enrichment": 3.3,
+     "grey_enrichment": 2.4,
+     "gdo2_wo": 8.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154, 271, 275, 279, 283, 287, 291]
+    },
+    {"name": "Z49B6",
+     "enrichment": 4.95,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154]
+    },
+    {"name": "Z49B9",
+     "enrichment": 4.95,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 5.0,
+     "grey_pos": [114, 118, 122, 130, 134, 138, 146, 150, 154]
+    },
+    {"name": "Z33Z9",
+     "enrichment": 3.3,
+     "grey_enrichment": 2.4,
+     "gdo2_wo": 8,
+     "grey_pos": [114, 118, 122, 130, 134, 138, 146, 150, 154]############
+    },
+    {"name": "Z49Y7",
+     "enrichment": 4.95,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 8.0,
+     "grey_pos": [63, 66, 72, 75, 81, 84, 90, 93, 99, 102, 108, 111,
+                   114, 122, 130, 138, 146, 154,
+                   205, 211, 217, 223, 229, 235,
+                   312, 316, 320]
+    },
+    {"name": "Z49Y9",
+     "enrichment": 4.95,
+     "grey_enrichment": 3.6,
+     "gdo2_wo": 8.0,
+     "grey_pos": [114, 122, 130, 138, 146, 154, 271, 279, 287]
     }
-
 ]
 
 def find_name(name, fas):

--- a/materials/fuel_assemblies.py
+++ b/materials/fuel_assemblies.py
@@ -13,3 +13,9 @@ fa_types = [
     }
 
 ]
+
+def find_name(name, fas):
+    for fa in fas:
+        if fa["name"] == name:
+            return fa
+    return None

--- a/materials/materials.py
+++ b/materials/materials.py
@@ -7,7 +7,7 @@ import openmc.model
 from fuel_assemblies import fa_types, find_name
 
 sys.path.append('../')
-from constants import split_number, core_height, csv_path, n_dif
+from constants import split_number, core_height, csv_path
 from constants import g1, g2, g3, g4, g5, h1, h2, h3, h4, h5, b_conc, dif_fu_cart
 
 #materials specifications
@@ -207,11 +207,11 @@ for i in range(0, len(g5)):
 if b_conc > eps:
     b_ppm = 1/(1 + 61.83/18 * (1/(b_conc*1E-3)-1)) * 1E6
     water = openmc.model.borated_water(boron_ppm = b_ppm, density=sum(density_hc)*1E-3/len(density_hc))
-    water.id = int(1E7 + 12E5 + n_dif*1E2 + split_number)
+    water.id = int(1E7 + 12E5 + len(dif_fu_cart)*1E2 + split_number)
     water.temperature = sum(hc_temp)/len(hc_temp) + 273.15
     water.name = 'H2O'
 else:
-    water = openmc.Material(material_id = int(1E7 + 12E5 + n_dif*1E2 + split_number), name="H2O")
+    water = openmc.Material(material_id = int(1E7 + 12E5 + len(dif_fu_cart)*1E2 + split_number), name="H2O")
     water.add_element('H', 2.0)
     water.add_element('O', 1.0)
     water.set_density('g/cm3', sum(density_hc)*1E-3/len(density_hc))
@@ -220,7 +220,7 @@ else:
 coolant.append(water)
 
 #reactor vessel steel SA-508
-steel_all = openmc.Material(material_id = int(1E7 + 13E5 + n_dif*1E2 + split_number),name="SA508")
+steel_all = openmc.Material(material_id = int(1E7 + 13E5 + len(dif_fu_cart)*1E2 + split_number),name="SA508")
 steel_all.add_element('C', 0.206,'wo')
 steel_all.add_element('Si', 0.321, 'wo')
 steel_all.add_element('Mn', 1.280, 'wo')

--- a/materials/materials.py
+++ b/materials/materials.py
@@ -167,8 +167,8 @@ for i in range(0, len(dif_fu_cart)):
             water.temperature = hc_temp[j] + 273.15
             water.add_s_alpha_beta('c_H_in_H2O')
         coolant.append(water)
-    grey_rods.append(grey_rod)
-
+    if type["gdo2_wo"] != 0:
+        grey_rods.append(grey_rod)
 cr_shell1 = []
 boron_carbide1 = []
 

--- a/materials/materials.py
+++ b/materials/materials.py
@@ -68,7 +68,7 @@ def cr_steel(i, j, num, temp):
 
 def b4c(i, j, num, temp):
     b4c_ = openmc.Material(material_id = int(1E7 + num * 1E5 + i*1E2 + j), name = "b4c_absorber")
-    b4c_.set_density('g/cm3', 1.7)
+    b4c_.set_density('g/cm3', 1.8)
     b4c_.add_element('B', 4.0, enrichment=80.0, enrichment_target='B10')
     b4c_.add_element('C', 1.0)
     b4c_.temperature = temp


### PR DESCRIPTION
Added the ability to form an active zone using a cartogram with the names of fuel assemblies. Each name refers to a dictionary that indicates the enrichment of fuel, the location of fuel rods with a burnout absorber, and other information necessary for calculation. In the current configuration of the core, it was possible to obtain the following Kq distribution.
![Graph13](https://github.com/user-attachments/assets/22a5aa9e-6753-4873-b038-58343a747358)
